### PR TITLE
Doc improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-readme
+        version: latest
+        use-tool-cache: true
+    - name: Readme
+      run: cargo readme > README.md && git diff --exit-code
     - name: Format
       run: cargo fmt --all -- --check
     - name: Build

--- a/README.md
+++ b/README.md
@@ -1,14 +1,49 @@
-
 ![Pipeline](https://github.com/rustne-kretser/atomic_once_cell/actions/workflows/rust.yml/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/atomic_once_cell.svg)](https://crates.io/crates/atomic_once_cell)
 [![API reference](https://docs.rs/atomic_once_cell/badge.svg)](https://docs.rs/atomic_once_cell/)
 
-# Overview
+# atomic_once_cell
 
-This crate provides two new types:
+`atomic_once_cell` provides two new types, [`AtomicOnceCell`] and
+[`AtomicLazy`], which are thread-safe and lock-free versions of
+[`core::lazy::OnceCell`] and [`core::lazy::Lazy`] suitable for use
+in `#[no_std]` environments.
 
-- [`AtomicOnceCell`](https://docs.rs/atomic_once_cell/struct.AtomicOnceCell.html), 
-- [`AtomicLazy`](https://docs.rs/atomic_once_cell/struct.AtomicLazy.html), 
+### Blocking
+
+Both types can be used in a non-blocking way, but there are some
+blocking calls that should not be used from interrupt handlers or
+other contexts where blocking will lead to a deadlock. Blocking is
+based on
+[`crossbeam::utils::Backoff`](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html),
+and will be reduced to a spin lock in `#[no_std]` environments.
+
+### Examples
+#### `AtomicOnceCell`
+
+```rust
+use atomic_once_cell::AtomicOnceCell;
+
+static CELL: AtomicOnceCell<String> = AtomicOnceCell::new();
+
+fn main() {
+    CELL.set("Hello, World!".to_owned()).unwrap();
+
+    assert_eq!(*CELL.get().unwrap(), "Hello, World!");
+}
+```
+
+#### `AtomicLazy`
+
+```rust
+use atomic_once_cell::AtomicLazy;
+
+static LAZY: AtomicLazy<String> = AtomicLazy::new(|| "Hello, World!".to_owned());
+
+fn main() {
+    assert_eq!(*LAZY, "Hello, World!");
+}
+```
 
 For more details, see [docs](https://docs.rs/atomic_once_cell/).
 
@@ -18,5 +53,9 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-atomic_once_cell = "0.1.0"
+atomic_once_cell = "0.1.1"
 ```
+
+# License
+
+MPL-2.0

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,22 @@
+![Pipeline](https://github.com/rustne-kretser/atomic_once_cell/actions/workflows/rust.yml/badge.svg)
+[![Crates.io](https://img.shields.io/crates/v/atomic_once_cell.svg)](https://crates.io/crates/atomic_once_cell)
+[![API reference](https://docs.rs/atomic_once_cell/badge.svg)](https://docs.rs/atomic_once_cell/)
+
+# {{crate}}
+
+{{readme}}
+
+For more details, see [docs](https://docs.rs/atomic_once_cell/).
+
+# Usage
+
+Add this to your Cargo.toml:
+
+```toml
+[dependencies]
+atomic_once_cell = "{{version}}"
+```
+
+# License
+
+{{license}}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ unsafe impl<T> Sync for AtomicOnceCell<T> where T: Send + Sync {}
 /// following pattern is recommended:
 ///
 /// ```ignore
-/// static ITEM: AtomicOnceCell<Item> = AtomicOnceCell::new();
+/// static ITEM: AtomicLazy<Item> = AtomicLazy::new();
 ///
 /// fn interrupt_handler() {
 ///     let item = ITEM.get().unwrap_or_else(|| unreachable!());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,18 +358,24 @@ unsafe impl<T> Sync for AtomicOnceCell<T> where T: Send + Sync {}
 /// handler. To use `AtomicLazy` in an interrupt handler, the
 /// following pattern is recommended:
 ///
-/// ```ignore
-/// static ITEM: AtomicLazy<Item> = AtomicLazy::new();
+/// ```
+/// use atomic_once_cell::AtomicLazy;
+///
+/// static LAZY: AtomicLazy<String> = AtomicLazy::new(|| "Hello, World!".to_owned());
 ///
 /// fn interrupt_handler() {
-///     let item = ITEM.get().unwrap_or_else(|| unreachable!());
-///     [...]
+///     let item = AtomicLazy::get(&LAZY).unwrap_or_else(|| unreachable!());
+///     assert_eq!(*item, "Hello, World!");
+///     // [...]
 /// }
 ///
 /// fn main() {
-///     ITEM.init();
-///     // <- Enable interrupt here
-///     [...]
+///     AtomicLazy::init(&LAZY);
+///     assert_eq!(*LAZY, "Hello, World!");
+///     // [...] <- Enable interrupt here
+///     interrupt_handler(); // interrupt handler called
+///                          // asynchronously at some point
+///     // [...]
 /// }
 
 pub struct AtomicLazy<T, F = fn() -> T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,44 @@
 
 //! `atomic_once_cell` provides two new types, [`AtomicOnceCell`] and
 //! [`AtomicLazy`], which are thread-safe and lock-free versions of
-//! [`core::lazy::OnceCell`] and [`core::lazy::Lazy`].
+//! [`core::lazy::OnceCell`] and [`core::lazy::Lazy`] suitable for use
+//! in `#[no_std]` environments.
+//!
+//! ## Blocking
+//!
+//! Both types can be used in a non-blocking way, but there are some
+//! blocking calls that should not be used from interrupt handlers or
+//! other contexts where blocking will lead to a deadlock. Blocking is
+//! based on
+//! [`crossbeam::utils::Backoff`](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html),
+//! and will be reduced to a spin lock in `#[no_std]` environments.
+//!
+//! ## Examples
+//! ### `AtomicOnceCell`
+//!
+//! ```
+//! use atomic_once_cell::AtomicOnceCell;
+//!
+//! static CELL: AtomicOnceCell<String> = AtomicOnceCell::new();
+//!
+//! fn main() {
+//!     CELL.set("Hello, World!".to_owned()).unwrap();
+//!
+//!     assert_eq!(*CELL.get().unwrap(), "Hello, World!");
+//! }
+//! ```
+//!
+//! ### `AtomicLazy`
+//!
+//! ```
+//! use atomic_once_cell::AtomicLazy;
+//!
+//! static LAZY: AtomicLazy<String> = AtomicLazy::new(|| "Hello, World!".to_owned());
+//!
+//! fn main() {
+//!     assert_eq!(*LAZY, "Hello, World!");
+//! }
+//! ```
 
 #![no_std]
 
@@ -198,7 +235,10 @@ impl<T> AtomicOnceCell<T> {
     /// # Blocking
     ///
     /// This method might block and should not be used from an
-    /// interrupt handler.
+    /// interrupt handler. Blocking is based on
+    /// [`crossbeam::utils::Backoff`](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html),
+    /// and will be reduced to a spin lock in `#[no_std]`
+    /// environments.
     ///
     /// # Panics
     ///
@@ -233,7 +273,10 @@ impl<T> AtomicOnceCell<T> {
     /// # Blocking
     ///
     /// This method might block and should not be used from an
-    /// interrupt handler.
+    /// interrupt handler. Blocking is based on
+    /// [`crossbeam::utils::Backoff`](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html),
+    /// and will be reduced to a spin lock in `#[no_std]`
+    /// environments.
     ///
     /// # Panics
     ///
@@ -451,7 +494,10 @@ where
     /// # Blocking
     ///
     /// This method might block and should not be used from an
-    /// interrupt handler.
+    /// interrupt handler. Blocking is based on
+    /// [`crossbeam::utils::Backoff`](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html),
+    /// and will be reduced to a spin lock in `#[no_std]`
+    /// environments.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
- Example for interrupt handler for `AtomicLazy` doesn't work or even compile.
- Added top-level examples.
- Generate readme from template to avoid double book-keeping.