### PR TITLE
Make crossbeam-utils dep default-features = false to allow building without std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 
 [dependencies]
 atomic-polyfill = "0.1.8"
-crossbeam-utils = "0.8.5"
+crossbeam-utils = { version = "0.8.5", default-features = false }
 
 [target.'cfg(loom)'.dependencies]
 loom =  "0.5.4"


### PR DESCRIPTION
Without this, this crate (atomic_once_cell) requires std due to a dependency through crossbeam-utils.