### PR TITLE
Use immutable reference in `get()` to keep miri happy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Use immutable reference in `AtomicOnceCell` to keep miri happy.
 
 ## [0.1.4] - 2023-03-22
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ include = [
 ]
 
 [dependencies]
-atomic-polyfill = "0.1.8"
-crossbeam-utils = { version = "0.8.5", default-features = false }
+atomic-polyfill = "1.0.2"
+crossbeam-utils = { version = "0.8.15", default-features = false }
 
 [target.'cfg(loom)'.dependencies]
-loom =  "0.5.4"
+loom =  "0.5.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,10 @@ impl<T> AtomicOnceCell<T> {
         self.state.load(Ordering::Acquire) == State::Ready.into()
     }
 
+    unsafe fn cell(&self) -> &Option<T> {
+        &*self.inner.get()
+    }
+
     unsafe fn cell_mut(&self) -> &mut Option<T> {
         &mut *self.inner.get()
     }
@@ -179,7 +183,7 @@ impl<T> AtomicOnceCell<T> {
     /// Returns `None` if the cell is empty.
     pub fn get(&self) -> Option<&T> {
         if self.is_ready() {
-            let cell = unsafe { self.cell_mut() };
+            let cell = unsafe { self.cell() };
 
             cell.as_ref()
         } else {


### PR DESCRIPTION
- `get()` used `cell_mut()` to get reference, even though only immutable reference is needed. This isn't a problem, but makes miri unhappy.
- Added `cell()` returning an immutable reference. This keeps miri happy, and expresses the intent more clearly.

Closes #14 