### PR TITLE
Bump to version 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.1.5] - 2023-03-25
+### Fixed
 - Use immutable reference in `AtomicOnceCell` to keep miri happy.
 
 ## [0.1.4] - 2023-03-22

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomic_once_cell"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Eivind Alexander Bergem <eivind.bergem@gmail.com>"]
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-atomic_once_cell = "0.1.4"
+atomic_once_cell = "0.1.5"
 ```
 
 # License


### PR DESCRIPTION
## [0.1.5] - 2023-03-25
### Fixed
- Use immutable reference in `AtomicOnceCell` to keep miri happy.

## [0.1.4] - 2023-03-22
### Changed
- Use `atomic-polyfill` to support targets without CAS or atomic load/store.
- Make crossbeam-utils dep default-features = false to allow building without std
