### PR TITLE
feat: add `crossbeam` feature, enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `crossbeam` feature, enabled by default, to enable `crossbeam-utils` dependency and `AtomicLazy` struct.
+
 ## [0.2.0] - 2025-02-13
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 
 [dependencies]
 portable-atomic = "1"
-crossbeam-utils = { version = "0.8.15", default-features = false }
+crossbeam-utils = { version = "0.8.15", default-features = false, optional = true }
 serde = { version = "1.0.171", optional = true }
 
 [target.'cfg(loom)'.dependencies]
@@ -26,5 +26,6 @@ loom =  "0.7.0"
 serde_json = "1.0.104"
 
 [features]
-default = []
-serde = ["dep:serde"]
+default = ["crossbeam"]
+crossbeam = ["dep:crossbeam-utils"]
+serde = ["dep:serde"] 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ lock-free (if you know a way, please tell me).
 Both types can be used in a non-blocking way, but there are some
 blocking calls that should not be used from interrupt handlers or
 other contexts where blocking will lead to a deadlock. Blocking is
-based on
-[`crossbeam::utils::Backoff`](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html),
-and will be reduced to a spinlock in `#[no_std]` environments.
+based on [`crossbeam::utils::Backoff`] and will be reduced to a spinlock
+in `#[no_std]` environments. This is enabled via `crossbeam` feature.
+
+[`crossbeam::utils::Backoff`]: https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html,
 
 ### Examples
 #### `AtomicOnceCell`


### PR DESCRIPTION
Hi, I would like to use this crate (`AtomicOnceCell::{set, get}`), but I would want to avoid a dependency on crossbeam utils. This PR just adds an ability to opt out from this.